### PR TITLE
Updating k8s clientgo

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/IBM/secret-common-lib
 go 1.18
 
 require (
-	github.com/IBM/secret-utils-lib v1.1.5
+	github.com/IBM/secret-utils-lib v1.1.6
 	github.com/go-playground/validator/v10 v10.11.1
 	go.uber.org/zap v1.20.0
 	google.golang.org/grpc v1.47.0
@@ -63,7 +63,7 @@ require (
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/api v0.26.1 // indirect
 	k8s.io/apimachinery v0.26.1 // indirect
-	k8s.io/client-go v0.0.0-00010101000000-000000000000 // indirect
+	k8s.io/client-go v0.26.1 // indirect
 	k8s.io/klog/v2 v2.80.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20221012153701-172d655c2280 // indirect
 	k8s.io/utils v0.0.0-20221107191617-1a15be271d1d // indirect

--- a/go.sum
+++ b/go.sum
@@ -37,8 +37,8 @@ github.com/BurntSushi/toml v1.0.0/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbi
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/IBM/go-sdk-core/v5 v5.9.1 h1:06pXbD9Rgmqqe2HA5YAeQbB4eYRRFgIoOT+Kh3cp1zo=
 github.com/IBM/go-sdk-core/v5 v5.9.1/go.mod h1:axE2JrRq79gIJTjKPBwV6gWHswvVptBjbcvvCPIxARM=
-github.com/IBM/secret-utils-lib v1.1.5 h1:USfEpQO3BqUNezxxOzrsCe4PHizCKfXJgp00gQLBhfQ=
-github.com/IBM/secret-utils-lib v1.1.5/go.mod h1:RuD7z7GrfI/RS5UmQTfY51qWTgscMy06zbQi7i433TY=
+github.com/IBM/secret-utils-lib v1.1.6 h1:uYmGKvsc+//qIvj/5zXsqknFtQR/tF3wXsRUD9piiAI=
+github.com/IBM/secret-utils-lib v1.1.6/go.mod h1:Gq0ZtLZDUaGaeO4Im8RT1IGJaKaHwAzcMNjvCoPAklw=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef h1:46PFijGLmAjMPwCCCo7Jf0W6f9slllCkkv7vyc1yOSg=
 github.com/asaskevich/govalidator v0.0.0-20200907205600-7a23bdc65eef/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=


### PR DESCRIPTION
Adding this change as the following issue was observed

```
go get github.com/IBM/secret-common-lib
go: k8s.io/client-go@v0.0.0-00010101000000-000000000000: invalid version: unknown revision 000000000000
```